### PR TITLE
fix: Add microdelay to `shift down` commands in applescript to address quicknav shift chord issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,10 @@
       "integrity": "sha512-NDdfpdQ6rZlylgv++iMn5FkObC/QlBQvipinGLSOguTYpRywmieOyJ29XHvUilspwTFSILWpoE9CqMGkHXug1g==",
       "dev": true
     },
+    "node_modules/@bocoup/macos-at-driver-server": {
+      "resolved": "packages/macos-at-driver-server",
+      "link": true
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
@@ -894,10 +898,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/macos-at-driver-server": {
-      "resolved": "packages/macos-at-driver-server",
-      "link": true
-    },
     "node_modules/mimic-response": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
@@ -1745,7 +1745,8 @@
       }
     },
     "packages/macos-at-driver-server": {
-      "version": "0.0.4",
+      "name": "@bocoup/macos-at-driver-server",
+      "version": "0.0.5",
       "license": "MIT",
       "bin": {
         "at-driver": "shared/bin/at-driver"

--- a/shared/helpers/macos/applescript.js
+++ b/shared/helpers/macos/applescript.js
@@ -62,11 +62,12 @@ exports.renderScript = function (command) {
     .reverse()
     .map(code => {
       const keyCode = KeyCode[code].toString();
-      // Add delay after shift key press for VoiceOver to properly recognize the modifier
-      if (code === KeyCode.shift) {
-        return { code, down: `key down ${keyCode}\ndelay 0.05`, up: `key up ${keyCode}` };
-      }
-      return { code, down: `key down ${keyCode}`, up: `key up ${keyCode}` };
+      return {
+        code,
+        // Add delay after shift key press for VoiceOver event resolver to properly recognize the modifier
+        down: code === KeyCode.shift ? `key down ${keyCode}\ndelay 0.05` : `key down ${keyCode}`,
+        up: `key up ${keyCode}`,
+      };
     })
     .reduce((accum, { down, up }) => `${down}\n${accum}\n${up}`, '')
     .split('\n')

--- a/test/helpers/macos/applescript.js
+++ b/test/helpers/macos/applescript.js
@@ -89,6 +89,7 @@ suite('helpers/macos/applescript', () => {
             '        key down 55\n' +
             '        key down 58\n' +
             '        key down shift\n' +
+            '        delay 0.05\n' +
             '        key down 11\n' +
             '        \n' +
             '        key up 11\n' +


### PR DESCRIPTION
see [aria-at-app/#1254](https://github.com/w3c/aria-at-app/issues/1254)

This PR addresses issues with shift chord commands by adding a microdelay after the `shift down` command in the applescript rendered by the driver server. The theory is that the delay forces sequential resolution from System Events. Note that this PR is in draft until we get internal consensus on applying the delay to all shift chords. No negative consequences were detected with other `shift + key + setting` combinations in local testing. 