### PR TITLE
Fix for VO truncation on tests with repeated key presses

### DIFF
--- a/packages/macos-at-driver-server/package.json
+++ b/packages/macos-at-driver-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bocoup/macos-at-driver-server",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Bocoup",
   "license": "MIT",
   "description": "A WebSocket server which allows clients to observe the text enunciated by a screen reader and to simulate user input using macOS",

--- a/packages/macos-at-driver-server/package.json
+++ b/packages/macos-at-driver-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bocoup/macos-at-driver-server",
-  "version": "0.0.8",
+  "version": "0.0.7",
   "author": "Bocoup",
   "license": "MIT",
   "description": "A WebSocket server which allows clients to observe the text enunciated by a screen reader and to simulate user input using macOS",

--- a/shared/helpers/macos/applescript.js
+++ b/shared/helpers/macos/applescript.js
@@ -22,6 +22,9 @@ const APPLESCRIPT_TIMEOUT = 5;
 /** Error message to look for to determine error is an Applescript time out. */
 const APPLESCRIPT_TIMEOUT_ERROR = (exports.APPLESCRIPT_TIMEOUT_ERROR = 'AppleEvent timed out');
 
+const SHIFT_CHORD_DELAY = 0.05;
+const KEYPRESS_DELAY = 0.25;
+
 exports.KeyboardAction = KeyboardAction;
 
 exports.KeyCode = KeyCode;
@@ -64,11 +67,14 @@ exports.renderScript = function (command) {
       const keyCode = KeyCode[code].toString();
       return {
         // Add delay after shift key press for VoiceOver event resolver to properly recognize the modifier
-        down: code === KeyCode.shift ? `key down ${keyCode}\ndelay 0.05` : `key down ${keyCode}`,
+        down:
+          code === KeyCode.shift
+            ? `key down ${keyCode}\ndelay ${SHIFT_CHORD_DELAY}`
+            : `key down ${keyCode}`,
         up: `key up ${keyCode}`,
       };
     })
-    .reduce((accum, { down, up }) => `${down}\n${accum}\n${up}`, '')
+    .reduce((accum, { down, up }) => `${down}\n${accum}\n${up}\ndelay ${KEYPRESS_DELAY}`, '')
     .split('\n')
     .map(line => `${INDENT}${INDENT}${line}`)
     .join('\n');

--- a/test/helpers/macos/applescript.js
+++ b/test/helpers/macos/applescript.js
@@ -57,6 +57,7 @@ suite('helpers/macos/applescript', () => {
             '        key down 49\n' +
             '        \n' +
             '        key up 49\n' +
+            '        delay 0.25\n' +
             '    end tell\n' +
             'end timeout',
         ),
@@ -73,7 +74,9 @@ suite('helpers/macos/applescript', () => {
             '        key down 0\n' +
             '        \n' +
             '        key up 0\n' +
+            '        delay 0.25\n' +
             '        key up 58\n' +
+            '        delay 0.25\n' +
             '    end tell\n' +
             'end timeout',
         ),
@@ -93,9 +96,13 @@ suite('helpers/macos/applescript', () => {
             '        key down 11\n' +
             '        \n' +
             '        key up 11\n' +
+            '        delay 0.25\n' +
             '        key up shift\n' +
+            '        delay 0.25\n' +
             '        key up 58\n' +
+            '        delay 0.25\n' +
             '        key up 55\n' +
+            '        delay 0.25\n' +
             '    end tell\n' +
             'end timeout',
         ),


### PR DESCRIPTION
fixes https://github.com/w3c/aria-at/issues/1164

Adds a general microdelay after every keypress to account for cases when a keypress is repeated in a test (for example: Assertion Results for "Control+Option+Left Arrow, then Control+Option+Left Arrow, then Control+Option+Left Arrow" in the Disclosure pattern tests).

VO output now consistently matches the expected output described by manual testers in https://github.com/w3c/aria-at/issues/1164