### PR TITLE
Extend timeout value for tests in CI

### DIFF
--- a/test/test-macos-key-press.js
+++ b/test/test-macos-key-press.js
@@ -32,6 +32,9 @@ const { Builder } = require('selenium-webdriver');
 const { renderScript, runScript } = require('../shared/helpers/macos/applescript');
 const { KeyCodeCommandKind } = require('../shared/helpers/macos/keyCodeCommand');
 
+// Allow for longer delays when starting the browsing session when executing
+// these tests in resource-constrained continuous-integration environments.
+const WEBDRIVER_SESSION_TIMEOUT = process.env.CI ? 20 * 1000 : 10 * 1000;
 const documentHTML = `<!DOCTYPE html>
 <html lang="en">
   <body>
@@ -88,7 +91,7 @@ suite('macOS key press simulation', () => {
   const keyTest = keyTestDriverRef.bind(null, () => driver);
 
   suiteSetup(async function () {
-    this.timeout(10 * 1000);
+    this.timeout(WEBDRIVER_SESSION_TIMEOUT);
     driver = await new Builder().forBrowser('firefox').build();
   });
 


### PR DESCRIPTION
The CI environment currently used by the project has been observed to require between 1497ms and 10398ms to start a WebDriver session with Firefox. Increase the upper limit to accommodate the worst-case scenario, but do so only when the test suite is known to be running in the continuous integration environment.

---

(I collected data on the current performance by patching the test suite to measuring timings and [triggering a CI job using that patched version](https://github.com/bocoup/at-driver-servers/actions/runs/12187228611/job/33997546330).)