### PR TITLE
Provide a meaningful error when CWD does not exist

### DIFF
--- a/shared/install/macos.js
+++ b/shared/install/macos.js
@@ -30,12 +30,15 @@ const PLUGIN_TRIPLET_IDENTIFIER = 'ausp atdg BOCU';
  * Execute the "exec" method from the built-in `child_process` module. In the
  * event of failure due to the absence of the specified current working
  * directory, provide a meaningful error description.
+ *
+ * @param {string} command
+ * @param {ExecOptions} [options]
  */
-const exec = async (...args) => {
+const exec = async (command, options) => {
   try {
-    return await promisify(_exec)(...args);
+    return await promisify(_exec)(command, options);
   } catch (error) {
-    const cwd = args[1]?.cwd || process.cwd();
+    const cwd = options?.cwd || process.cwd();
     const cwdExists = !!(await fs.stat(cwd).catch(() => null));
 
     if (error.code === 'ENOENT' && !cwdExists) {

--- a/shared/install/macos.js
+++ b/shared/install/macos.js
@@ -39,7 +39,7 @@ const exec = async (...args) => {
     const cwdExists = !!(await fs.stat(cwd).catch(() => null));
 
     if (error.code === 'ENOENT' && !cwdExists) {
-      throw new Error(`Cannot access directory: ${cwd}`, {cause: error});
+      throw new Error(`Cannot access directory: ${cwd}`, { cause: error });
     }
 
     throw error;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
     "compilerOptions": {
         "checkJs": true,
-        "noEmit": true
+        "module": "commonjs",
+        "noEmit": true,
+        "target": "es2022"
     },
     "include": ["shared", "test"]
 }


### PR DESCRIPTION
Prior to this commit, if a command was executed in a non-existing current working directory, the "exec" method of the built-in `child_process` module would throw an error that only partially described the problem, e.g.

    Error: spawn /bin/sh ENOENT
        at ChildProcess._handle.onexit (node:internal/child_process:284:19)
        at onErrorNT (node:internal/child_process:477:16)
        at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
      errno: -2,
      code: 'ENOENT',
      syscall: 'spawn /bin/sh',
      path: '/bin/sh',
      spawnargs: [
        '-c',
        '/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted -u MacOSATDriverServer.app'
      ],
      cmd: '/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted -u MacOSATDriverServer.app',
      stdout: '',
      stderr: ''
    }

Detect this specific error condition and provide a more detailed description, e.g.

    Error: Cannot access directory: /Users/example/packages/macos-at-driver-server/MacOSATDriverServer/Build/Debug
        at exec (/Users/example/packages/macos-at-driver-server/shared/install/macos.js:42:13)
        at async unregisterExtensions (/Users/example/packages/macos-at-driver-server/shared/install/macos.js:195:3)
        at async exports.uninstall (/Users/example/packages/macos-at-driver-server/shared/install/macos.js:123:3)
        at async Object.handler (/Users/example/packages/macos-at-driver-server/shared/commands/uninstall.js:13:5) {
      [cause]: Error: spawn /bin/sh ENOENT
          at ChildProcess._handle.onexit (node:internal/child_process:284:19)
          at onErrorNT (node:internal/child_process:477:16)
          at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
        errno: -2,
        code: 'ENOENT',
        syscall: 'spawn /bin/sh',
        path: '/bin/sh',
        spawnargs: [
          '-c',
          '/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted -u MacOSATDriverServer.app'
        ],
        cmd: '/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted -u MacOSATDriverServer.app',
        stdout: '',
        stderr: ''
      }
    }

---

@ChrisC: This should clear up the issue that you and I (and @stalgiag [before us](https://github.com/bocoup/at-driver-servers/issues/9)) have observed.