### PR TITLE
Refactor in terms of user intents

### DIFF
--- a/shared/install/macos.js
+++ b/shared/install/macos.js
@@ -7,7 +7,7 @@ const { promisify } = require('util');
 
 const debug = require('debug')('install');
 
-const { 'interaction.pressKeys': pressKeys } = require('../modules/macos/interaction');
+const { 'interaction.userIntent': userIntent } = require('../modules/macos/interaction');
 
 const LSREGISTER_EXECUTABLE_PATH =
   '/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister';
@@ -134,7 +134,7 @@ exports.uninstall = async function () {
  */
 const canPressKeys = async () => {
   try {
-    await pressKeys(null, { keys: ['shift'] });
+    await userIntent(null, { name: 'pressKeys', keys: ['shift'] });
   } catch ({}) {
     return false;
   }

--- a/shared/modules/macos/interaction.js
+++ b/shared/modules/macos/interaction.js
@@ -5,13 +5,16 @@
 const { runScript, renderScript } = require('../../helpers/macos/applescript');
 const { parseCodePoints } = require('../../helpers/macos/parseCodePoints');
 
-const pressKeys = /** @type {ATDriverModules.InteractionPressKeys} */ (
-  async function (websocket, { keys }) {
+const userIntent = /** @type {ATDriverModules.InteractionUserIntent} */ (
+  async function (websocket, { name, keys }) {
+    if (name !== 'pressKeys') {
+      throw new Error('unknown user intent');
+    }
     await runScript(renderScript(parseCodePoints(keys)));
     return {};
   }
 );
 
 module.exports = /** @type {ATDriverModules.Interaction} */ ({
-  'interaction.pressKeys': pressKeys,
+  'interaction.userIntent': userIntent,
 });

--- a/shared/modules/types.js
+++ b/shared/modules/types.js
@@ -24,16 +24,17 @@
 
 /**
  * @typedef ATDriverModules.InteractionPressKeysParameters
+ * @property {"pressKeys"} name
  * @property {ATDriverModules.InteractionPressKeysKeyCombination} keys
  */
 
 /**
- * @typedef {ATDriverModules.Command<ATDriverModules.InteractionPressKeysParameters, {}>} ATDriverModules.InteractionPressKeys
+ * @typedef {ATDriverModules.Command<ATDriverModules.InteractionPressKeysParameters, {}>} ATDriverModules.InteractionUserIntent
  */
 
 /**
  * @typedef {{
- *   "interaction.pressKeys": ATDriverModules.InteractionPressKeys
+ *   "interaction.userIntent": ATDriverModules.InteractionUserIntent
  * }} ATDriverModules.Interaction
  */
 

--- a/shared/modules/win32/interaction.js
+++ b/shared/modules/win32/interaction.js
@@ -69,8 +69,11 @@ const keyboardActionsMap = {
 
 const keycodeMatch = /[\ue000-\ue05d]/;
 
-const pressKeys = /** @type {ATDriverModules.InteractionPressKeys} */ (
-  (websocket, { keys }) => {
+const userIntent = /** @type {ATDriverModules.InteractionUserIntent} */ (
+  (websocket, { name, keys }) => {
+    if (name !== 'pressKeys') {
+      throw new Error('unknown user intent');
+    }
     const robotjsKeys = keys.map(key => {
       if (keyboardActionsMap[key]) return keyboardActionsMap[key];
       if (keycodeMatch.test(key))
@@ -93,5 +96,5 @@ const pressKeys = /** @type {ATDriverModules.InteractionPressKeys} */ (
 );
 
 module.exports = /** @type {ATDriverModules.Interaction} */ ({
-  'interaction.pressKeys': pressKeys,
+  'interaction.userIntent': userIntent,
 });

--- a/test/test.js
+++ b/test/test.js
@@ -163,14 +163,16 @@ suite('at-driver', () => {
     });
 
     test('rejects Command messages with omitted "id"', async () => {
-      websocket.send('{"method": "interaction.pressKeys", "params": {"keys": ["A"]}}');
+      websocket.send(
+        '{"method": "interaction.userIntent", "params": {"name": "pressKeys", "keys": ["A"]}}',
+      );
       const message = await Promise.race([whenClosed, nextMessage(websocket)]);
 
       assert.deepEqual(message, {
         id: null,
         error: 'unknown error',
         message:
-          'Command missing required "id": "{"method": "interaction.pressKeys", "params": {"keys": ["A"]}}".',
+          'Command missing required "id": "{"method": "interaction.userIntent", "params": {"name": "pressKeys", "keys": ["A"]}}".',
       });
     });
 
@@ -184,8 +186,10 @@ suite('at-driver', () => {
       });
     });
 
-    test('accepts valid "pressKey" Command', async () => {
-      websocket.send('{"id": 83, "method": "interaction.pressKeys", "params": {"keys": [" "]}}');
+    test('accepts valid "userIntent" Command', async () => {
+      websocket.send(
+        '{"id": 83, "method": "interaction.userIntent", "params": {"name": "pressKeys", "keys": [" "]}}',
+      );
       const message = await Promise.race([whenClosed, nextMessage(websocket)]);
 
       assert.deepEqual(message, {
@@ -194,9 +198,22 @@ suite('at-driver', () => {
       });
     });
 
-    test('rejects invalid "pressKey" Command', async () => {
+    test('rejects unrecognized user intent', async () => {
       websocket.send(
-        '{"id": 902, "method": "interaction.pressKeys", "params": {"keys": ["df daf% ?"]}}',
+        '{"id": 902, "method": "interaction.userIntent", "params": {"name": "press Key"}}',
+      );
+      const message = await Promise.race([whenClosed, nextMessage(websocket)]);
+
+      assert.deepEqual(message, {
+        id: 902,
+        error: 'unknown error',
+        message: 'unknown user intent',
+      });
+    });
+
+    test('rejects invalid "pressKeys" user intent', async () => {
+      websocket.send(
+        '{"id": 902, "method": "interaction.userIntent", "params": {"name": "pressKeys", "keys": ["df daf% ?"]}}',
       );
       const message = await Promise.race([whenClosed, nextMessage(websocket)]);
 


### PR DESCRIPTION
Reflect the latest changes to the AT Driver specification, where "press keys" has been restructured as a parameters of a new "interaction" command designed for "user intents."