### PR TITLE
Graceful exit if install script detects installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prettier": "prettier --write shared test",
     "test": "npm run test-style && npm run test-types && npm run test-unit",
-    "test-macos-key-press": "mocha --ui tdd test/test-macos-key-press.js",
+    "test-macos-key-press": "mocha --ui tdd --timeout 5000 test/test-macos-key-press.js",
     "test-style": "prettier --check shared test",
     "test-types": "tsc -p tsconfig.json",
     "test-unit": "mocha --ui tdd --timeout 5000 test/test.js test/helpers/**/*.js"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-macos-key-press": "mocha --ui tdd test/test-macos-key-press.js",
     "test-style": "prettier --check shared test",
     "test-types": "tsc -p tsconfig.json",
-    "test-unit": "mocha --ui tdd test/test.js test/helpers/**/*.js"
+    "test-unit": "mocha --ui tdd --timeout 5000 test/test.js test/helpers/**/*.js"
   },
   "author": "",
   "license": "MIT",

--- a/shared/commands/install.js
+++ b/shared/commands/install.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { loadOsModule } = require('../helpers/load-os-module');
+const { install } = require('../install/macos');
 
 module.exports = /** @type {import('yargs').CommandModule} */ ({
   command: 'install',
@@ -12,12 +12,8 @@ module.exports = /** @type {import('yargs').CommandModule} */ ({
     });
   },
   async handler({ unattended }) {
-    const installDelegate = loadOsModule('install', {
-      darwin: () => require('../install/macos'),
-      win32: () => require('../install/win32'),
-    });
-    await installDelegate.install({ unattended });
-
-    console.log('Installation completed successfully.');
+    const installed = await install({ unattended });
+    const result = installed ? 'Installation completed successfully.' : 'Already installed';
+    console.log(result);
   },
 });

--- a/shared/commands/install.js
+++ b/shared/commands/install.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { install } = require('../install/macos');
+const { loadOsModule } = require('../helpers/load-os-module');
 
 module.exports = /** @type {import('yargs').CommandModule} */ ({
   command: 'install',
@@ -12,8 +12,10 @@ module.exports = /** @type {import('yargs').CommandModule} */ ({
     });
   },
   async handler({ unattended }) {
-    const installed = await install({ unattended });
-    const result = installed ? 'Installation completed successfully.' : 'Already installed';
-    console.log(result);
+    const installDelegate = loadOsModule('install', {
+      darwin: () => require('../install/macos'),
+      win32: () => require('../install/win32'),
+    });
+    await installDelegate.install({ unattended });
   },
 });

--- a/shared/install/macos.js
+++ b/shared/install/macos.js
@@ -83,7 +83,7 @@ const promptForManualKeyPress = async () => {
  * @param {boolean} options.unattended - Whether installation should fail if
  *                                       human intervention is required
  *
- * @returns {Promise<boolean>}
+ * @returns {Promise<void>}
  */
 exports.install = async function ({ unattended }) {
   const options = await getExecOptions();
@@ -103,14 +103,14 @@ exports.install = async function ({ unattended }) {
   }
 
   if (await isInstalled()) {
-    return false;
+    return console.log('Already installed.');
   }
 
   await removeQuarantine(options);
   await registerExtensions(options);
   await enableExtension();
   await setSystemVoice(VOICE_IDENTIFIER);
-  return true;
+  console.log('Installation completed successfully.');
 };
 
 /**

--- a/shared/install/macos.js
+++ b/shared/install/macos.js
@@ -83,7 +83,7 @@ const promptForManualKeyPress = async () => {
  * @param {boolean} options.unattended - Whether installation should fail if
  *                                       human intervention is required
  *
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>}
  */
 exports.install = async function ({ unattended }) {
   const options = await getExecOptions();
@@ -103,13 +103,14 @@ exports.install = async function ({ unattended }) {
   }
 
   if (await isInstalled()) {
-    throw new Error('Already installed');
+    return false;
   }
 
   await removeQuarantine(options);
   await registerExtensions(options);
   await enableExtension();
   await setSystemVoice(VOICE_IDENTIFIER);
+  return true;
 };
 
 /**

--- a/shared/install/win32.js
+++ b/shared/install/win32.js
@@ -10,6 +10,7 @@ const MAKE_VOICE_EXE = 'MakeVoice.exe';
 
 exports.install = async function () {
   await exec(`${MAKE_VOICE_EXE}`, await getExecOptions());
+  console.log('Installation completed successfully.');
 };
 
 exports.uninstall = async function () {


### PR DESCRIPTION
Rather than throwing an error when the install script detects that at-driver is already installed ([which causes a CI process to fail if at-driver is already installed)](https://github.com/bocoup/aria-at-gh-actions-helper-dev/actions/runs/15666901302/job/44132539831), let's just exit early and log what happened. 

This is necessary to permit automated installs of `at-driver` on long-lived self-hosted runners. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210700990113679